### PR TITLE
for HLS generation time improvement

### DIFF
--- a/src/StreamOpt.cpp
+++ b/src/StreamOpt.cpp
@@ -219,7 +219,7 @@ class ReplaceReferencesWithStencil : public IRMutator {
     }
 
     void visit(const Let *op) {
-        Expr new_value = simplify(expand_expr(mutate(op->value), scope));
+        Expr new_value = simplify(mutate(op->value));
         scope.push(op->name, new_value);
         Expr new_body = mutate(op->body);
         if (new_value.same_as(op->value) &&


### PR DESCRIPTION
@xuanyoya, this is the modification that shows much faster HLS generation for a design with many Param<>, I talked about before. In Halide IR, to expand and simplify doesn't get expression shorter but longer and process time increases exponentially if Param<> is included. Please take a look.
PS. Sorry for pushing directly to HLS branch by mistake without making a separate one.
