### PR TITLE
Fix Zynq code generation.

### DIFF
--- a/apps/hls_examples/demosaic_harris_hls/Makefile
+++ b/apps/hls_examples/demosaic_harris_hls/Makefile
@@ -14,7 +14,7 @@ run_hls: $(HLS_LOG)
 pipeline: pipeline.cpp
 	$(CXX) $(CXXFLAGS) -Wall -g $^ $(LIB_HALIDE) -o $@ $(LDFLAGS) -ltinfo
 
-pipeline_hls.cpp pipeline_native.o pipeline_zynq.o: pipeline
+pipeline_hls.cpp pipeline_native.o pipeline_zynq.c: pipeline
 	HL_DEBUG_CODEGEN=0 ./pipeline
 
 run: run.cpp pipeline_hls.cpp hls_target.cpp pipeline_native.o
@@ -34,8 +34,8 @@ $(HLS_LOG): ../hls_support/run_hls.tcl pipeline_hls.cpp run.cpp
 	RUN_ARGS=$(realpath ./../../images/zynq_raw.png) \
 	vivado_hls -f $< -l $(HLS_LOG)
 
-#pipeline_zynq.o: pipeline_zynq.c
-#	$(CXX) -c -O2 $(CXXFLAGS) -g -Wall -Werror $^ -o $@
+pipeline_zynq.o: pipeline_zynq.c
+	$(CXX) -c -O2 $(CXXFLAGS) -g -Wall -Werror $^ -o $@
 
 pipeline_zynq_bypass.o: pipeline_zynq_bypass.c
 	$(CXX) -c -O2 $(CXXFLAGS) -g -Wall -Werror $^ -o $@
@@ -60,3 +60,4 @@ clean:
 	rm -f pipeline_native.h pipeline_native.o
 	rm -f pipeline_hls.h pipeline_hls.cpp
 	rm -f hls_target.h hls_target.cpp
+	rm -f pipeline_zynq.c pipeline_zynq.o

--- a/apps/hls_examples/demosaic_harris_hls/pipeline.cpp
+++ b/apps/hls_examples/demosaic_harris_hls/pipeline.cpp
@@ -229,6 +229,7 @@ public:
         std::vector<Target::Feature> features({Target::Zynq});
         Target target(Target::Linux, Target::ARM, 32, features);
         output.compile_to_lowered_stmt("pipeline_zynq.ir.html", args, HTML, target);
+        output.compile_to_lowered_stmt("pipeline_zynq.stmt", args, Text, target);
         output.compile_to_zynq_c("pipeline_zynq.c", args, "pipeline_zynq", target);
         output.compile_to_header("pipeline_zynq.h", args, "pipeline_zynq", target);
         output.compile_to_object("pipeline_zynq.o", args, "pipeline_zynq", target);

--- a/src/CodeGen_C.cpp
+++ b/src/CodeGen_C.cpp
@@ -2435,7 +2435,8 @@ void CodeGen_C::visit(const Allocate *op) {
         alloc.type = op->type;
         allocations.push(op->name, alloc);
         heap_allocations.push(op->name, 0);
-        stream << op_type << "*" << op_name << " = (" << print_expr(op->new_expr) << ");\n";
+        string new_expr = print_expr(op->new_expr);
+        stream << op_type << "*" << op_name << " = reinterpret_cast<"<< op_type << "*>(" << new_expr  << ");\n";
     } else {
         constant_size = op->constant_allocation_size();
         if (constant_size > 0) {

--- a/src/CodeGen_Zynq_C.cpp
+++ b/src/CodeGen_Zynq_C.cpp
@@ -35,14 +35,21 @@ const string zynq_runtime =
     "  unsigned int mmap_offset;\n"
     "} cma_buffer_t;\n"
     "#endif\n"
+    "\n"
+    "#ifdef __cplusplus\n"
+    "extern \"C\" {\n"
+    "#endif\n"
     "// Zynq runtime API\n"
     "int halide_zynq_init();\n"
     "void halide_zynq_free(void *user_context, void *ptr);\n"
-    "int halide_zynq_cma_alloc(struct buffer_t *buf);\n"
-    "int halide_zynq_cma_free(struct buffer_t *buf);\n"
-    "int halide_zynq_subimage(const struct buffer_t* image, struct cma_buffer_t* subimage, void *address_of_subimage_origin, int width, int height);\n"
+    "int halide_zynq_cma_alloc(struct halide_buffer_t *buf);\n"
+    "int halide_zynq_cma_free(struct halide_buffer_t *buf);\n"
+    "int halide_zynq_subimage(const struct halide_buffer_t* image, struct cma_buffer_t* subimage, void *address_of_subimage_origin, int width, int height);\n"
     "int halide_zynq_hwacc_launch(struct cma_buffer_t bufs[]);\n"
-    "int halide_zynq_hwacc_sync(int task_id);\n";
+    "int halide_zynq_hwacc_sync(int task_id);\n"
+    "#ifdef __cplusplus\n"
+    "}  // extern \"C\" {\n"
+    "#endif\n";
 }
 
 CodeGen_Zynq_C::CodeGen_Zynq_C(ostream &dest,

--- a/src/InjectZynqIntrinsics.cpp
+++ b/src/InjectZynqIntrinsics.cpp
@@ -1,19 +1,57 @@
 #include "InjectZynqIntrinsics.h"
+
 #include "IRMutator.h"
 #include "IROperator.h"
+#include "Substitute.h"
 
 namespace Halide {
 namespace Internal {
+namespace {
 
 using std::string;
 using std::vector;
 using std::map;
 
-/*
+// Set the host field of any buffer_init calls on the given buffer to null.
+class NullifyHostField : public IRMutator {
+    using IRMutator::visit;
+    void visit(const Variable *op) {
+        if (op->name == buf_name) {
+            expr = make_zero(Handle());
+        } else {
+            expr = op;
+        }
+    }
+    std::string buf_name;
+public:
+    NullifyHostField(const std::string &b) : buf_name(b) {}
+};
+
+Stmt call_extern_and_assert(const string& name, const vector<Expr>& args) {
+    Expr call = Call::make(Int(32), name, args, Call::Extern);
+    string call_result_name = unique_name(name + "_result");
+    Expr call_result_var = Variable::make(Int(32), call_result_name);
+    return LetStmt::make(call_result_name, call,
+                         AssertStmt::make(EQ::make(call_result_var, 0), call_result_var));
+}
+
 class InjectCmaIntrinsics : public IRMutator {
     const map<string, Function> &env;
 
     using IRMutator::visit;
+
+    Stmt make_zynq_malloc(const string &buf_name) const {
+        Expr buf = Variable::make(type_of<struct halide_buffer_t *>(), buf_name + ".buffer");
+        Stmt device_malloc = call_extern_and_assert("halide_zynq_cma_alloc", {buf});
+        return device_malloc;
+    }
+
+    Stmt make_zynq_free(const string &buf_name) const {
+        Expr buf = Variable::make(type_of<struct halide_buffer_t *>(), buf_name + ".buffer");
+        Stmt device_free = Evaluate::make(Call::make(Int(32), "halide_zynq_cma_free",
+                                                     {buf}, Call::Extern));
+        return device_free;
+    }
 
     void visit(const Allocate *op) {
         auto iter = env.find(op->name);
@@ -29,44 +67,52 @@ class InjectCmaIntrinsics : public IRMutator {
             debug(3) << "find a kernel buffer " << op->name << "\n";
             // function (accessed by the accelerator pipeline) are scheduled to store in kernel buffer
             // we want to use cma (contiguous memory allocator)
-            // The IR is like:
+            // IR before:
+            //   allocate hw_output[uint8 * WIDTH * HEIGHT]
+            //   let hw_output.buffer = _halide_buffer_init(...)
             //
-            //  let buffer_name.zerocopy_buffer = create_buffer_t(null_handle(), ...)
-            //  let zynq_cma_alloc_result = halide_zynq_cma_alloc(buffer_name.zerocopy_buffer)
-            //  assert((zynq_cma_alloc_result == 0), zynq_cma_alloc_result)
-            //  allocate buffer_name[...]custom_new{buffer_name.zerocopy_buffer.host}custom_delete{ halide_zynq_free(); }
-            // get the args from a previously inserted create_buffer_t call
+            // IR after:
+            //   let hw_output.buffer = _halide_buffer_init(...)
+            //   let halide_zynq_cma_malloc_result = halide_zynq_cma_malloc(hw_output.buffer)
+            //   assert((halide_zynq_cma_malloc_result == 0), halide_zynq_cma_malloc_result)
+            //   allocate hw_output[uint8 * WIDTH * HEIGHT] in Heap
+            //   ....
+            //   halide_zynq_cma_free(hw_output.buffer)
+
+            // Get the args from a previously inserted buffer_init call
             // and pop the call out from the body
-            const LetStmt *lets = op->body.as<LetStmt>();
-            internal_assert(lets);
-            const Call *buf = lets->value.as<Call>();
-            internal_assert(buf && buf->name == Call::create_buffer_t);
-            Stmt new_body = mutate(lets->body);
+            const string buffer_name = op->name;
+            const LetStmt *buffer_init_let = op->body.as<LetStmt>();
+            internal_assert(buffer_init_let && buffer_init_let->name == op->name + ".buffer");
+            Expr let_value = substitute_in_all_lets(buffer_init_let->value);
+            const Call *buffer_init_call = let_value.as<Call>();
+            internal_assert(buffer_init_call && buffer_init_call->name == Call::buffer_init) << Expr(buffer_init_call) << "\n";
+            Stmt inner_body = mutate(buffer_init_let->body);
 
-            // allocate node
-            string zerocopy_buffer_name = op->name + ".buffer";
-            Expr zerocopy_buffer = Variable::make(type_of<struct buffer_t *>(), zerocopy_buffer_name);
-            Expr new_expr = Call::make(Handle(), Call::extract_buffer_host, {zerocopy_buffer}, Call::Intrinsic);
-            string free_function = "halide_zynq_free";
+            Stmt zynq_malloc = make_zynq_malloc(op->name);
+            Stmt zynq_free = make_zynq_free(op->name);
 
-            Stmt free = Evaluate::make(Call::make(Int(32), "halide_zynq_cma_free", {zerocopy_buffer}, Call::Intrinsic));
-            stmt = Allocate::make(op->name, op->type, op->extents, op->condition, Block::make(new_body, free), new_expr, free_function);
+            // Create a new Allocation scope inside the buffer
+            // creation, use the host pointer as the allocation and
+            // set the destructor to a nop.
+            inner_body = Allocate::make(op->name, op->type, op->extents, op->condition, inner_body,
+                                        Call::make(Handle(), Call::buffer_get_host,
+                                                   { Variable::make(type_of<struct halide_buffer_t *>(), op->name + ".buffer") },
+                                                   Call::Extern),
+                                        "halide_zynq_free");
+            // Wrap malloc and free around Allocate.
+            inner_body = Block::make(zynq_malloc, inner_body);
+            inner_body = Block::make(inner_body, zynq_free);
 
-            // call to halide_zynq_cma_alloc and assertion
-            string call_result_name = unique_name("zynq_cma_alloc_result");
-            Expr call_result_var = Variable::make(Int(32), call_result_name);
-            Expr call = Call::make(Int(32), "halide_zynq_cma_alloc", {zerocopy_buffer}, Call::Intrinsic);
-            stmt = Block::make(LetStmt::make(call_result_name, call, AssertStmt::make(call_result_var == 0, call_result_var)), stmt);
-
-            // create the new buffer_t
-            vector<Expr> args = buf->args;
-            args[0] = Call::make(Handle(), Call::null_handle, {}, Call::PureIntrinsic);
-            Expr zerocopy_buf = Call::make(type_of<struct buffer_t *>(),
-                                           Call::create_buffer_t,
-                                           args, Call::Intrinsic);
-            stmt = LetStmt::make(zerocopy_buffer_name,  zerocopy_buf, stmt);
-
-
+            // Rewrite original buffer_init call and wrap it around the combined malloc.
+            // The original buffer_init call uses address_of on the
+            // allocate node. We want it to be initially null and let
+            // the zynq_malloc fill it in instead. The
+            // Allocate node was just rewritten to just grab this
+            // pointer out of the buffer after the combined
+            // allocation, so no memory is dropped.
+            Expr buf = NullifyHostField(op->name).mutate(buffer_init_let->value);
+            stmt = LetStmt::make(op->name + ".buffer", buf, inner_body);
         } else {
             IRMutator::visit(op);
         }
@@ -76,14 +122,14 @@ public:
     InjectCmaIntrinsics(const map<string, Function> &e)
         : env(e) {}
 };
-*/
+
+}  // namespace
 
 Stmt inject_zynq_intrinsics(Stmt s,
                             const map<string, Function> &env) {
     // TODO(jingpu) check it we still need this after implementing device_interface
-    //return InjectCmaIntrinsics(env).mutate(s);
-    return s;
+    return InjectCmaIntrinsics(env).mutate(s);
 }
 
-}
-}
+}  // namespace Internal
+}  // namespace Halide


### PR DESCRIPTION
Re-enable the inject_zynq_intrinsics pass, which was disabled when Halide upstream switched to use halide_buffer_t as the primary underlying storage. Also fixed a couple issue in the zynq code generation after the Halide update.