### PR TITLE
Upgrade halide zynq runtime to halide_buffer_t

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -697,6 +697,10 @@ ifeq ($(UNAME), Darwin)
 	install_name_tool -id $(CURDIR)/$(BIN_DIR)/libHalide.$(SHARED_EXT) $(BIN_DIR)/libHalide.$(SHARED_EXT)
 endif
 
+zynq_runtime: $(LIB_DIR)/libHalide.a $(ROOT_DIR)/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp $(INCLUDE_DIR)/HalideRuntime.h
+	$(CXX) -c -Wall $(ROOT_DIR)/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp -o $(BUILD_DIR)/HalideRuntimeZynq.o -I$(INCLUDE_DIR)
+	ar rvs $(LIB_DIR)/libZynqRuntime.a $(BUILD_DIR)/HalideRuntimeZynq.o
+
 $(INCLUDE_DIR)/Halide.h: $(HEADERS) $(SRC_DIR)/HalideFooter.h $(BIN_DIR)/build_halide_h
 	mkdir -p $(INCLUDE_DIR)
 	$(BIN_DIR)/build_halide_h $(HEADERS) $(SRC_DIR)/HalideFooter.h > $(INCLUDE_DIR)/Halide.h

--- a/Makefile
+++ b/Makefile
@@ -697,7 +697,7 @@ ifeq ($(UNAME), Darwin)
 	install_name_tool -id $(CURDIR)/$(BIN_DIR)/libHalide.$(SHARED_EXT) $(BIN_DIR)/libHalide.$(SHARED_EXT)
 endif
 
-zynq_runtime: $(LIB_DIR)/libHalide.a $(ROOT_DIR)/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp $(INCLUDE_DIR)/HalideRuntime.h
+zynq_runtime: $(ROOT_DIR)/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp $(INCLUDE_DIR)/HalideRuntime.h
 	$(CXX) -c -Wall $(ROOT_DIR)/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp -o $(BUILD_DIR)/HalideRuntimeZynq.o -I$(INCLUDE_DIR)
 	ar rvs $(LIB_DIR)/libZynqRuntime.a $(BUILD_DIR)/HalideRuntimeZynq.o
 

--- a/test/scripts/build_travis.sh
+++ b/test/scripts/build_travis.sh
@@ -60,7 +60,7 @@ elif [ ${BUILD_SYSTEM} = 'MAKE' ]; then
 
   # Build the docs and run the tests
   #make doc test_correctness test_generators test_hls_apps
-  make test_hls_apps test_correctness test_generators
+  make test_hls_apps test_correctness test_generators zynq_runtime
 else
   echo "Unexpected BUILD_SYSTEM: \"${BUILD_SYSTEM}\""
   exit 1


### PR DESCRIPTION
This PR, based on #28, upgraded `HalideRuntimeZynq` to use `halide_buffer_t` instead of deprecated `buffer_t`.

For applications relying on Zynq CodeGen, they need to link `HalideRuntimeZynq` to interact with the kernel drivers.