### PR TITLE
More readable HLS arg name

### DIFF
--- a/src/CodeGen_HLS_Target.cpp
+++ b/src/CodeGen_HLS_Target.cpp
@@ -146,8 +146,8 @@ string CodeGen_HLS_Target::CodeGen_HLS_C::get_arg_name(const string &arg_name,
     }
     pos = name.find(".");
     if (pos != std::string::npos) {
-        /* $ does compile, but it's more confusing since it implies a naming
-         * conflift in Halide */
+        // $ does compile, but it's more confusing since it implies a naming
+        // conflift in Halide
         if (name.find("$") == std::string::npos)
             return name.substr(0, pos);
     }

--- a/src/CodeGen_HLS_Target.cpp
+++ b/src/CodeGen_HLS_Target.cpp
@@ -196,7 +196,7 @@ void CodeGen_HLS_Target::CodeGen_HLS_C::add_kernel(Stmt stmt,
                << "#pragma HLS INTERFACE s_axilite port=return"
                << " bundle=config\n";
         for (size_t i = 0; i < args.size(); i++) {
-            string arg_name = "arg_" + std::to_string(i);
+            string arg_name = guess_name(args[i].name, i);
             if (args[i].is_stencil) {
                 if (ends_with(args[i].name, ".stream")) {
                     // stream arguments use AXI-stream interface
@@ -222,7 +222,7 @@ void CodeGen_HLS_Target::CodeGen_HLS_C::add_kernel(Stmt stmt,
         do_indent();
         stream << "// alias the arguments\n";
         for (size_t i = 0; i < args.size(); i++) {
-            string arg_name = "arg_" + std::to_string(i);
+            string arg_name = guess_name(args[i].name, i);
             do_indent();
             if (args[i].is_stencil) {
                 CodeGen_HLS_Base::Stencil_Type stype = args[i].stencil_type;

--- a/src/CodeGen_HLS_Target.cpp
+++ b/src/CodeGen_HLS_Target.cpp
@@ -135,17 +135,13 @@ string CodeGen_HLS_Target::CodeGen_HLS_C::print_stencil_pragma(const string &nam
     return oss.str();
 }
 
-string CodeGen_HLS_Target::CodeGen_HLS_C::guess_name(const string &arg_name,
-                                                     uint32_t index) {
+string CodeGen_HLS_Target::CodeGen_HLS_C::get_arg_name(const string &arg_name,
+                                                       uint32_t index) {
 
-    /**
-     * Attempt to extract useful names from the arg name.
-     * If it fails, fall back to arg_%d as before.
-     */
     string name = arg_name;
     auto pos = name.find(":");
     if (pos != std::string::npos) {
-        /* we don't need the pipe: part */
+        // we don't need the pipe: part
         name = name.substr(++pos);
     }
     pos = name.find(".");
@@ -155,7 +151,7 @@ string CodeGen_HLS_Target::CodeGen_HLS_C::guess_name(const string &arg_name,
         if (name.find("$") == std::string::npos)
             return name.substr(0, pos);
     }
-    /* fall back */
+    // fall back
     return "arg_" + std::to_string(index);
 }
 
@@ -165,7 +161,7 @@ void CodeGen_HLS_Target::CodeGen_HLS_C::add_kernel(Stmt stmt,
     // Emit the function prototype
     stream << "void " << name << "(\n";
     for (size_t i = 0; i < args.size(); i++) {
-        string arg_name = guess_name(args[i].name, i);
+        string arg_name = get_arg_name(args[i].name, i);
         if (args[i].is_stencil) {
             CodeGen_HLS_Base::Stencil_Type stype = args[i].stencil_type;
             internal_assert(args[i].stencil_type.type == Stencil_Type::StencilContainerType::AxiStream ||
@@ -196,7 +192,7 @@ void CodeGen_HLS_Target::CodeGen_HLS_C::add_kernel(Stmt stmt,
                << "#pragma HLS INTERFACE s_axilite port=return"
                << " bundle=config\n";
         for (size_t i = 0; i < args.size(); i++) {
-            string arg_name = guess_name(args[i].name, i);
+            string arg_name = get_arg_name(args[i].name, i);
             if (args[i].is_stencil) {
                 if (ends_with(args[i].name, ".stream")) {
                     // stream arguments use AXI-stream interface
@@ -222,7 +218,7 @@ void CodeGen_HLS_Target::CodeGen_HLS_C::add_kernel(Stmt stmt,
         do_indent();
         stream << "// alias the arguments\n";
         for (size_t i = 0; i < args.size(); i++) {
-            string arg_name = guess_name(args[i].name, i);
+            string arg_name = get_arg_name(args[i].name, i);
             do_indent();
             if (args[i].is_stencil) {
                 CodeGen_HLS_Base::Stencil_Type stype = args[i].stencil_type;

--- a/src/CodeGen_HLS_Target.h
+++ b/src/CodeGen_HLS_Target.h
@@ -63,7 +63,7 @@ protected:
          * Attempt to extract useful names from the arg name.
          * If it fails, fall back to arg_%d as before.
          */
-        static std::string get_arg_name(const std::string &name, uint32_t index);
+        static std::string get_arg_name(const std::string &name, uint32_t index) const;
     };
 
     /** A name for the HLS target */

--- a/src/CodeGen_HLS_Target.h
+++ b/src/CodeGen_HLS_Target.h
@@ -63,7 +63,7 @@ protected:
          * Attempt to extract useful names from the arg name.
          * If it fails, fall back to arg_%d as before.
          */
-        static std::string get_arg_name(const std::string &name, uint32_t index) const;
+        static std::string get_arg_name(const std::string &name, uint32_t index);
     };
 
     /** A name for the HLS target */

--- a/src/CodeGen_HLS_Target.h
+++ b/src/CodeGen_HLS_Target.h
@@ -59,7 +59,11 @@ protected:
         void visit(const For *op);
         void visit(const Allocate *op);
     private:
-        std::string guess_name(const std::string &name, uint32_t index);
+        /**
+         * Attempt to extract useful names from the arg name.
+         * If it fails, fall back to arg_%d as before.
+         */
+        static std::string get_arg_name(const std::string &name, uint32_t index);
     };
 
     /** A name for the HLS target */

--- a/src/CodeGen_HLS_Target.h
+++ b/src/CodeGen_HLS_Target.h
@@ -58,6 +58,8 @@ protected:
 
         void visit(const For *op);
         void visit(const Allocate *op);
+    private:
+        std::string guess_name(const std::string &name, uint32_t index);
     };
 
     /** A name for the HLS target */


### PR DESCRIPTION
Introduced a `guess_name` function in HLS codegen so that instead of using `arg_%d`, it's now using more human readable naming used in Halide code. This is extremely helpful because user now can specify the DMA channel loading order in the driver code automatically, given the `pipeline_zynq` buffer preparing sequence. If the code fails to guess the argument name, it will fall back to `arg_%d`.
- We've rewrote `hwacc` driver code so that it reads information directly from device tree, instead of through parametrization (one driver to rule them all.)