### PR TITLE
Add halide_zynq_set_fd()

### DIFF
--- a/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp
+++ b/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp
@@ -92,14 +92,14 @@ int halide_zynq_init() {
     fd_cma = open("/dev/cmabuffer0", O_RDWR, 0644);
     if(fd_cma == -1) {
         printf("Failed to open cma provider!\n");
-        fd_cma = fd_hwacc = 0;
+        halide_zynq_set_fd(0, 0);
         return -2;
     }
     fd_hwacc = open("/dev/hwacc0", O_RDWR, 0644);
     if(fd_hwacc == -1) {
         printf("Failed to open hwacc device!\n");
         close(fd_cma);
-        fd_cma = fd_hwacc = 0;
+        halide_zynq_set_fd(0, 0);
         return -2;
     }
     return 0;

--- a/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp
+++ b/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp
@@ -70,6 +70,20 @@ extern "C" {
 static int fd_hwacc = 0;
 static int fd_cma = 0;
 
+int halide_zynq_set_fd(int hwacc, int cma) {
+    if (!hwacc) {
+        printf("hwacc is uninitialized\n");
+        return -1;
+    }
+    if (!cma) {
+        printf("cma is uninitialized\n");
+        return -1;
+    }
+    fd_hwacc = hwacc;
+    fd_cma = cma;
+    return 0;
+}
+
 int halide_zynq_init() {
     if (fd_cma || fd_hwacc) {
         printf("Zynq runtime is already initialized.\n");

--- a/src/runtime/HalideRuntimeZynq.h
+++ b/src/runtime/HalideRuntimeZynq.h
@@ -35,6 +35,12 @@ typedef struct cma_buffer_t {
 } cma_buffer_t;
 #endif
 
+
+/**
+ * Set Zynq runtime by providing char driver file descriptor
+ */
+extern int halide_zynq_set_fd(int hwacc, int cma);
+
 /** Initialize Zynq runtime environment and must be called
     before any other function from the runtime API. */
 extern int halide_zynq_init();

--- a/src/runtime/zynq.cpp
+++ b/src/runtime/zynq.cpp
@@ -58,14 +58,14 @@ WEAK int halide_zynq_init() {
     fd_cma = open("/dev/cmabuffer0", O_RDWR, 0644);
     if(fd_cma == -1) {
         error(NULL) << "Failed to open cma provider!\n";
-        fd_cma = fd_hwacc = 0;
+        halide_zynq_set_fd(0, 0);
         return -2;
     }
     fd_hwacc = open("/dev/hwacc0", O_RDWR, 0644);
     if(fd_hwacc == -1) {
         error(NULL) << "Failed to open hwacc device!\n";
         close(fd_cma);
-        fd_cma = fd_hwacc = 0;
+        halide_zynq_set_fd(0, 0);
         return -2;
     }
     return 0;

--- a/src/runtime/zynq.cpp
+++ b/src/runtime/zynq.cpp
@@ -35,6 +35,20 @@ extern int munmap(void *addr, size_t length);
 static int fd_hwacc = 0;
 static int fd_cma = 0;
 
+WEAK int halide_zynq_set_fd(int hwacc, int cma) {
+    if (!hwacc) {
+        error(NULL) << "hwacc is uninitialized\n";
+        return -1;
+    }
+    if (!cma) {
+        error(NULL) << "cma is uninitialized\n";
+        return -1;
+    }
+    fd_hwacc = hwacc;
+    fd_cma = cma;
+    return 0;
+}
+
 WEAK int halide_zynq_init() {
     debug(0) << "halide_zynq_init\n";
     if (fd_cma || fd_hwacc) {


### PR DESCRIPTION
Add `halide_zynq_set_fd()` to allow external modification on `fd_hwacc` and `fd_cma` via `dlopen()`, while keep the API clean.