### PR TITLE
Switch to new ubuffer interface

### DIFF
--- a/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp
+++ b/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp
@@ -36,31 +36,58 @@ typedef struct buffer_t {
 } buffer_t;
 #endif
 
-#ifndef CMA_BUFFER_T_DEFINED
-#define CMA_BUFFER_T_DEFINED
-struct mMap;
-typedef struct cma_buffer_t {
-  unsigned int id; // ID flag for internal use
-  unsigned int width; // Width of the image
-  unsigned int stride; // Stride between rows, in pixels. This must be >= width
-  unsigned int height; // Height of the image
-  unsigned int depth; // Byte-depth of the image
-  unsigned int phys_addr; // Bus address for DMA
-  void* kern_addr; // Kernel virtual address
-  struct mMap* cvals;
-  unsigned int mmap_offset;
-} cma_buffer_t;
-#endif
+/**
+ * Userspace buffer
+ */
+#ifndef _UBUFFER_H_
+#define _UBUFFER_H_
+
+#ifdef __KERNEL__
+#include <linux/types.h>
+#define U32_TYPE    u32
+#else
+#include <stdint.h>
+#define U32_TYPE    uint32_t
+#endif /* __KERNEL__ */
+
+/* user buffer declaration */
+typedef struct UBuffer {
+    U32_TYPE id;        // ID flag for internal use
+    U32_TYPE offset;    // used for slicing purposes
+                        // this is the offset in bytes
+                        // from the beginning of root buffer
+    U32_TYPE width;     // width of the image
+    U32_TYPE height;    // height of the image
+    U32_TYPE stride;    // stride of the image
+    U32_TYPE depth;     // byte-depth of the image
+} UBuffer;
+
+#endif /* _UBUFFER_H_ */
 
 #ifndef _IOCTL_CMDS_H_
 #define _IOCTL_CMDS_H_
-// TODO: switch these out for "proper" mostly-system-unique ioctl numbers
-#define GET_BUFFER 1000 // Get an unused buffer
-#define GRAB_IMAGE 1001 // Acquire image from camera
-#define FREE_IMAGE 1002 // Release buffer
-#define PROCESS_IMAGE 1003 // Push to stencil path
-#define PEND_PROCESSED 1004 // Retreive from stencil path
-#endif
+
+#define MAGIC           'Z'
+
+/* cma driver */
+#define GET_BUFFER      _IOWR(MAGIC, 0x20, void *)   // Get an unused buffer
+#define FREE_BUFFER     _IOWR(MAGIC, 0x21, void *)   // Release buffer
+
+/* dma driver */
+#define ENROLL_BUFFER   _IOWR(MAGIC, 0x40, void *)
+#define WAIT_COMPLETE   _IOWR(MAGIC, 0x41, void *)
+#define STATUS_CHECK    _IOWR(MAGIC, 0x42, void *)
+#define DMA_COMPLETED   2
+#define DMA_IN_PROGRESS 1
+
+/* hwacc */
+#define GRAB_IMAGE      _IOWR(MAGIC, 0x22, void *)  // Acquire image from camera
+#define FREE_IMAGE      _IOWR(MAGIC, 0x23, void *)  // Release buffer
+#define PROCESS_IMAGE   _IOWR(MAGIC, 0x24, void *)  // Push to stencil path
+#define PEND_PROCESSED  _IOWR(MAGIC, 0x25, void *)  // Retreive from stencil path
+#define READ_TIMER      _IOWR(MAGIC, 0x26, void *)  // Retreive hw timer count
+
+#endif /* _IOCTL_CMDS_H_ */
 
 #ifdef __cplusplus
 extern "C" {
@@ -109,11 +136,11 @@ void halide_zynq_free(void *user_context, void *ptr) {
     // do nothing
 }
 
-static int cma_get_buffer(cma_buffer_t* ptr) {
+static int cma_get_buffer(UBuffer* ptr) {
     return ioctl(fd_cma, GET_BUFFER, (long unsigned int)ptr);
 }
 
-static int cma_free_buffer(cma_buffer_t* ptr) {
+static int cma_free_buffer(UBuffer* ptr) {
     return ioctl(fd_cma, FREE_IMAGE, (long unsigned int)ptr);
 }
 
@@ -123,7 +150,7 @@ int halide_zynq_cma_alloc(struct halide_buffer_t *buf) {
         return -1;
     }
 
-    cma_buffer_t *cbuf = (cma_buffer_t *)malloc(sizeof(cma_buffer_t));
+    UBuffer *cbuf = (UBuffer *)malloc(sizeof(UBuffer));
     if (cbuf == NULL) {
         printf("malloc failed.\n");
         return -1;
@@ -136,7 +163,7 @@ int halide_zynq_cma_alloc(struct halide_buffer_t *buf) {
     size_t nDims = buf->dimensions;
     if (nDims < 2) {
         free(cbuf);
-        printf("buffer_t has less than 2 dimension, not supported in CMA driver.");
+        printf("buffer_t has less than 2 dimension, not supported in CMA driver.\n");
         return -3;
     }
     cbuf->depth = (buf->type.bits + 7) / 8;
@@ -155,10 +182,10 @@ int halide_zynq_cma_alloc(struct halide_buffer_t *buf) {
         printf("cma_get_buffer() returned %d (failed).\n", status);
         return -2;
     }
-
+    uint32_t cma_buf_id = cbuf->id << 12;
     buf->device = (uint64_t) cbuf;
     buf->host = (uint8_t*) mmap(NULL, cbuf->stride * cbuf->height * cbuf->depth,
-                                PROT_WRITE, MAP_SHARED, fd_cma, cbuf->mmap_offset);
+                                PROT_WRITE, MAP_SHARED, fd_cma, cma_buf_id);
 
     if ((void *) buf->host == (void *) -1) {
         free(cbuf);
@@ -173,25 +200,33 @@ int halide_zynq_cma_free(struct halide_buffer_t *buf) {
         printf("Zynq runtime is uninitialized.\n");
         return -1;
     }
-
-    cma_buffer_t *cbuf = (cma_buffer_t *)buf->device;
+	UBuffer *cbuf = (UBuffer *)buf->device;
     munmap((void*)buf->host, cbuf->stride * cbuf->height * cbuf->depth);
     cma_free_buffer(cbuf);
     free(cbuf);
+    buf->device = 0;
     return 0;
 }
 
-int halide_zynq_subimage(const struct halide_buffer_t* image, struct cma_buffer_t* subimage, void *address_of_subimage_origin, int width, int height) {
-    *subimage = *((cma_buffer_t *)image->device); // copy depth, stride, data, etc.
+int halide_zynq_subimage(const struct halide_buffer_t* image, struct UBuffer* subimage, void *address_of_subimage_origin, int width, int height) {
+    *subimage = *((UBuffer *)image->device); // copy depth, stride, data, etc.
     subimage->width = width;
     subimage->height = height;
     size_t offset = (uint8_t *)address_of_subimage_origin - image->host;
-    subimage->phys_addr += offset;
-    subimage->mmap_offset += offset;
+
+    //subimage->phys_addr += offset;
+    //subimage->mmap_offset += offset;
+
+    /* the current implementation doesn't support offset any more */
+    if (offset != 0) {
+        printf("subimage offset not 0\n");
+        return -1;
+    }
+
     return 0;
 }
 
-int halide_zynq_hwacc_launch(struct cma_buffer_t bufs[]) {
+int halide_zynq_hwacc_launch(struct UBuffer bufs[]) {
     if (fd_hwacc == 0) {
         printf("Zynq runtime is uninitialized.\n");
         return -1;

--- a/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp
+++ b/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp
@@ -166,7 +166,7 @@ int halide_zynq_cma_alloc(struct halide_buffer_t *buf) {
         printf("buffer_t has less than 2 dimension, not supported in CMA driver.\n");
         return -3;
     }
-    cbuf->depth = (buf->type.bits + 7) / 8;
+    cbuf->depth = buf->type.bytes();
     if (nDims > 2) {
         for (size_t i = 0; i < nDims - 2; i++) {
             cbuf->depth *= buf->dim[i].extent;
@@ -200,7 +200,7 @@ int halide_zynq_cma_free(struct halide_buffer_t *buf) {
         printf("Zynq runtime is uninitialized.\n");
         return -1;
     }
-	UBuffer *cbuf = (UBuffer *)buf->device;
+    UBuffer *cbuf = (UBuffer *)buf->device;
     munmap((void*)buf->host, cbuf->stride * cbuf->height * cbuf->depth);
     cma_free_buffer(cbuf);
     free(cbuf);
@@ -216,12 +216,7 @@ int halide_zynq_subimage(const struct halide_buffer_t* image, struct UBuffer* su
 
     //subimage->phys_addr += offset;
     //subimage->mmap_offset += offset;
-
-    /* the current implementation doesn't support offset any more */
-    if (offset != 0) {
-        printf("subimage offset not 0\n");
-        return -1;
-    }
+    subimage->offset = offset;
 
     return 0;
 }

--- a/src/CodeGen_Zynq_C.cpp
+++ b/src/CodeGen_Zynq_C.cpp
@@ -20,21 +20,25 @@ namespace {
 
 // copied from src/runtime/zynq.cpp
 const string zynq_runtime =
-    "#ifndef CMA_BUFFER_T_DEFINED\n"
-    "#define CMA_BUFFER_T_DEFINED\n"
-    "struct mMap;\n"
-    "typedef struct cma_buffer_t {\n"
-    "  unsigned int id; // ID flag for internal use\n"
-    "  unsigned int width; // Width of the image\n"
-    "  unsigned int stride; // Stride between rows, in pixels. This must be >= width\n"
-    "  unsigned int height; // Height of the image\n"
-    "  unsigned int depth; // Byte-depth of the image\n"
-    "  unsigned int phys_addr; // Bus address for DMA\n"
-    "  void* kern_addr; // Kernel virtual address\n"
-    "  struct mMap* cvals;\n"
-    "  unsigned int mmap_offset;\n"
-    "} cma_buffer_t;\n"
-    "#endif\n"
+    "#ifndef _UBUFFER_H_\n"
+    "#define _UBUFFER_H_\n"
+    "#ifdef __KERNEL__\n"
+    "#include <linux/types.h>\n"
+    "#define U32_TYPE   u32\n"
+    "#else\n"
+    "#include <stdint.h>\n"
+    "#define U32_TYPE   uint32_t\n"
+    "#endif /* __KERNEL__ */\n"
+    "/* user buffer declaration */\n"
+    "typedef struct UBuffer {\n"
+        "U32_TYPE id;           // ID flag for internal use\n"
+        "U32_TYPE offset;       // used for slicing purposes\n"
+        "U32_TYPE width;        // width of the image\n"
+        "U32_TYPE height;       // height of the image\n"
+        "U32_TYPE stride;       // stride of the image\n"
+        "U32_TYPE depth;        // byte-depth of the image\n"
+    "} UBuffer;\n"
+    "#endif /* _UBUFFER_H_ */\n"
     "\n"
     "#ifdef __cplusplus\n"
     "extern \"C\" {\n"
@@ -44,8 +48,8 @@ const string zynq_runtime =
     "void halide_zynq_free(void *user_context, void *ptr);\n"
     "int halide_zynq_cma_alloc(struct halide_buffer_t *buf);\n"
     "int halide_zynq_cma_free(struct halide_buffer_t *buf);\n"
-    "int halide_zynq_subimage(const struct halide_buffer_t* image, struct cma_buffer_t* subimage, void *address_of_subimage_origin, int width, int height);\n"
-    "int halide_zynq_hwacc_launch(struct cma_buffer_t bufs[]);\n"
+    "int halide_zynq_subimage(const struct halide_buffer_t* image, struct UBuffer* subimage, void *address_of_subimage_origin, int width, int height);\n"
+    "int halide_zynq_hwacc_launch(struct UBuffer bufs[]);\n"
     "int halide_zynq_hwacc_sync(int task_id);\n"
     "#ifdef __cplusplus\n"
     "}  // extern \"C\" {\n"
@@ -66,7 +70,7 @@ void CodeGen_Zynq_C::visit(const Realize *op) {
     buffer_slices.push_back(slice_name);
 
     do_indent();
-    stream << "cma_buffer_t " << print_name(slice_name) << ";\n";
+    stream << "UBuffer " << print_name(slice_name) << ";\n";
     // Recurse
     print_stmt(op->body);
     close_scope(slice_name);
@@ -76,7 +80,7 @@ void CodeGen_Zynq_C::visit(const ProducerConsumer *op) {
     if (op->is_producer && starts_with(op->name, "_hls_target.")) {
         // reachs the HW boundary
         /* C code:
-           cma_buffer_t kbufs[3];
+           UBuffer kbufs[3];
            kbufs[0] = kbuf_in0;
            kbufs[1] = kbuf_in1;
            kbufs[2] = kbuf_out;
@@ -86,7 +90,7 @@ void CodeGen_Zynq_C::visit(const ProducerConsumer *op) {
         // TODO check the order of buffer slices is consistent with
         // the order of DMA ports in the driver
         do_indent();
-        stream << "cma_buffer_t _cma_bufs[" << buffer_slices.size() << "];\n";
+        stream << "UBuffer _cma_bufs[" << buffer_slices.size() << "];\n";
         for (size_t i = 0; i < buffer_slices.size(); i++) {
             do_indent();
             stream << "_cma_bufs[" << i << "] = " << print_name(buffer_slices[i]) << ";\n";

--- a/src/CodeGen_Zynq_LLVM.cpp
+++ b/src/CodeGen_Zynq_LLVM.cpp
@@ -17,7 +17,7 @@ CodeGen_Zynq_LLVM::CodeGen_Zynq_LLVM(Target t)
 
 void CodeGen_Zynq_LLVM::visit(const Realize *op) {
     internal_assert(ends_with(op->name, ".stream"));
-    llvm::StructType *kbuf_type = module->getTypeByName("struct.cma_buffer_t");
+    llvm::StructType *kbuf_type = module->getTypeByName("struct.UBuffer");
     internal_assert(kbuf_type);
     llvm::Constant *one = llvm::ConstantInt::get(i32_t, 1);
     Value *slice_ptr = builder->CreateAlloca(kbuf_type, one, op->name);
@@ -33,7 +33,7 @@ void CodeGen_Zynq_LLVM::visit(const ProducerConsumer *op) {
     if (op->is_producer && starts_with(op->name, "_hls_target.")) {
         // reachs the HW boundary
         /* C code:
-           cma_buffer_t kbufs[3];
+           UBuffer kbufs[3];
            kbufs[0] = kbuf_in0;
            kbufs[1] = kbuf_in1;
            kbufs[2] = kbuf_out;
@@ -42,7 +42,7 @@ void CodeGen_Zynq_LLVM::visit(const ProducerConsumer *op) {
         */
         // TODO check the order of buffer slices is consistent with
         // the order of DMA ports in the driver
-        llvm::StructType *kbuf_type = module->getTypeByName("struct.cma_buffer_t");
+        llvm::StructType *kbuf_type = module->getTypeByName("struct.UBuffer");
         internal_assert(kbuf_type);
         Value *set_size = llvm::ConstantInt::get(i32_t, buffer_slices.size());
         Value *slice_set = builder->CreateAlloca(kbuf_type, set_size);

--- a/src/runtime/HalideRuntimeZynq.h
+++ b/src/runtime/HalideRuntimeZynq.h
@@ -11,30 +11,33 @@ extern "C" {
  *  Routines specific to the Zynq runtime.
  */
 
-#ifndef CMA_BUFFER_T_DEFINED
-#define CMA_BUFFER_T_DEFINED
-/** CMA (Continuous Memory Allocator) buffer struct passing
- * between Zynq low-level device driver calls. It stores
- * meta-data of a sub-image (2-D image tile), and the physical
- * address of the buffer used in DMA.
- *
- * It is originally defined in
- * https://github.com/stevenbell/zynqbuilder/blob/master/drivers/buffer.h
+/**
+ * Userspace buffer
  */
-struct mMap;
-typedef struct cma_buffer_t {
-  unsigned int id; // ID flag for internal use
-  unsigned int width; // Width of the image
-  unsigned int stride; // Stride between rows, in pixels. This must be >= width
-  unsigned int height; // Height of the image
-  unsigned int depth; // Byte-depth of the image
-  unsigned int phys_addr; // Bus address for DMA
-  void* kern_addr; // Kernel virtual address
-  struct mMap* cvals;
-  unsigned int mmap_offset;
-} cma_buffer_t;
-#endif
+#ifndef _UBUFFER_H_
+#define _UBUFFER_H_
 
+#ifdef __KERNEL__
+#include <linux/types.h>
+#define U32_TYPE    u32
+#else
+#include <stdint.h>
+#define U32_TYPE    uint32_t
+#endif /* __KERNEL__ */
+
+/* user buffer declaration */
+typedef struct UBuffer {
+    U32_TYPE id;        // ID flag for internal use
+    U32_TYPE offset;    // used for slicing purposes
+                        // this is the offset in bytes
+                        // from the beginning of root buffer
+    U32_TYPE width;     // width of the image
+    U32_TYPE height;    // height of the image
+    U32_TYPE stride;    // stride of the image
+    U32_TYPE depth;     // byte-depth of the image
+} UBuffer;
+
+#endif /* _UBUFFER_H_ */
 
 /**
  * Set Zynq runtime by providing char driver file descriptor
@@ -48,30 +51,30 @@ extern int halide_zynq_init();
 /** A special free function used in Zynq Target. It is emtpy. */
 extern void halide_zynq_free(void *user_context, void *ptr);
 
-/** Allocate and free a cma_buffer_t. Fields of the cma_buffer_t
+/** Allocate and free a UBuffer. Fields of the UBuffer
  * are set up according to the buffer_t argument. A pointer to
- * the cma_buffer_t is stored in buf->dev. And buf->dev is reset
- * to zero after the cma_buffer_t is freed.
+ * the UBuffer is stored in buf->dev. And buf->dev is reset
+ * to zero after the UBuffer is freed.
  */
 // @{
 extern int halide_zynq_cma_alloc(struct halide_buffer_t *buf);
 extern int halide_zynq_cma_free(struct halide_buffer_t *buf);
 // @}
 
-/** Create a new cma_buffer_t representing a sub-image tile of IMAGE
+/** Create a new UBuffer representing a sub-image tile of IMAGE
  * buffer. The sub-image tile starts at the user space address
  * ADDRESS_OF_SUBIMAGE_ORIGIN, and is WIDTH wide and HEIGHT tall.
  * The function only calcuates the meta-data and re-use the memory
  * buffer, so no copying happens.
  */
-extern int halide_zynq_subimage(const struct halide_buffer_t* image, struct cma_buffer_t* subimage, void *address_of_subimage_origin, int width, int height);
+extern int halide_zynq_subimage(const struct halide_buffer_t* image, struct UBuffer* subimage, void *address_of_subimage_origin, int width, int height);
 
 /** Launch a hardware accelerator run. BUFS stores the inputs and
  * output (sub-)image tiles used by DMAs.
  * The function returns immediately (non-blocking) with a task_id,
  * which can be used in other synchronization (blocking) functions.
  */
-extern int halide_zynq_hwacc_launch(struct cma_buffer_t bufs[]);
+extern int halide_zynq_hwacc_launch(struct UBuffer bufs[]);
 
 /** Block inside the function until the accelerator run with
  * TASK_ID finishes. */

--- a/src/runtime/zynq.cpp
+++ b/src/runtime/zynq.cpp
@@ -4,14 +4,60 @@
 #ifndef _IOCTL_CMDS_H_
 #define _IOCTL_CMDS_H_
 
-// TODO: switch these out for "proper" mostly-system-unique ioctl numbers
-#define GET_BUFFER 1000 // Get an unused buffer
-#define GRAB_IMAGE 1001 // Acquire image from camera
-#define FREE_IMAGE 1002 // Release buffer
-#define PROCESS_IMAGE 1003 // Push to stencil path
-#define PEND_PROCESSED 1004 // Retreive from stencil path
+// because LLVM/Halide tries to compile cross-platform, system-depedent calls such as
+// <sys/ioctl.h> can not be included normally. Copying over their macro to here
+// since Zynq is only valid for Linux os.
 
-#endif
+#define _IOC_NRBITS 8
+#define _IOC_TYPEBITS   8
+#define _IOC_SIZEBITS   13
+#define _IOC_DIRBITS    3
+
+#define _IOC_NRMASK ((1 << _IOC_NRBITS)-1)
+#define _IOC_TYPEMASK   ((1 << _IOC_TYPEBITS)-1)
+#define _IOC_SIZEMASK   ((1 << _IOC_SIZEBITS)-1)
+#define _IOC_DIRMASK    ((1 << _IOC_DIRBITS)-1)
+
+#define _IOC_NRSHIFT    0
+#define _IOC_TYPESHIFT  (_IOC_NRSHIFT+_IOC_NRBITS)
+#define _IOC_SIZESHIFT  (_IOC_TYPESHIFT+_IOC_TYPEBITS)
+#define _IOC_DIRSHIFT   (_IOC_SIZESHIFT+_IOC_SIZEBITS)
+
+#define _IOC_NONE   1U
+#define _IOC_READ   2U
+#define _IOC_WRITE  4U
+
+#define _IOC(dir,type,nr,size)          \
+    ((unsigned int)             \
+     (((dir)  << _IOC_DIRSHIFT) |       \
+      ((type) << _IOC_TYPESHIFT) |      \
+      ((nr)   << _IOC_NRSHIFT) |        \
+      ((size) << _IOC_SIZESHIFT)))
+
+
+#define _IOWR(type,nr,size) _IOC(_IOC_READ|_IOC_WRITE,(type),(nr),sizeof(size))
+
+#define MAGIC           'Z'
+
+/* cma driver */
+#define GET_BUFFER      _IOWR(MAGIC, 0x20, void *)   // Get an unused buffer
+#define FREE_BUFFER     _IOWR(MAGIC, 0x21, void *)   // Release buffer
+
+/* dma driver */
+#define ENROLL_BUFFER   _IOWR(MAGIC, 0x40, void *)
+#define WAIT_COMPLETE   _IOWR(MAGIC, 0x41, void *)
+#define STATUS_CHECK    _IOWR(MAGIC, 0x42, void *)
+#define DMA_COMPLETED   2
+#define DMA_IN_PROGRESS 1
+
+/* hwacc */
+#define GRAB_IMAGE      _IOWR(MAGIC, 0x22, void *)  // Acquire image from camera
+#define FREE_IMAGE      _IOWR(MAGIC, 0x23, void *)  // Release buffer
+#define PROCESS_IMAGE   _IOWR(MAGIC, 0x24, void *)  // Push to stencil path
+#define PEND_PROCESSED  _IOWR(MAGIC, 0x25, void *)  // Retreive from stencil path
+#define READ_TIMER      _IOWR(MAGIC, 0x26, void *)  // Retreive hw timer count
+
+#endif /* _IOCTL_CMDS_H_ */
 
 extern "C" {
 
@@ -76,11 +122,11 @@ WEAK void halide_zynq_free(void *user_context, void *ptr) {
     // do nothing
 }
 
-static int cma_get_buffer(cma_buffer_t* ptr) {
+static int cma_get_buffer(UBuffer* ptr) {
     return ioctl(fd_cma, GET_BUFFER, (long unsigned int)ptr);
 }
 
-static int cma_free_buffer(cma_buffer_t* ptr) {
+static int cma_free_buffer(UBuffer* ptr) {
     return ioctl(fd_cma, FREE_IMAGE, (long unsigned int)ptr);
 }
 
@@ -91,7 +137,7 @@ WEAK int halide_zynq_cma_alloc(struct halide_buffer_t *buf) {
         return -1;
     }
 
-    cma_buffer_t *cbuf = (cma_buffer_t *)malloc(sizeof(cma_buffer_t));
+    UBuffer *cbuf = (UBuffer *)malloc(sizeof(UBuffer));
     if (cbuf == NULL) {
         error(NULL) << "malloc failed.\n";
         return -1;
@@ -104,29 +150,29 @@ WEAK int halide_zynq_cma_alloc(struct halide_buffer_t *buf) {
     size_t nDims = buf->dimensions;
     if (nDims < 2) {
         free(cbuf);
-        error(NULL) << "buffer_t has less than 2 dimension, not supported in CMA driver.";
+        error(NULL) << "buffer_t has less than 2 dimension, not supported in CMA driver.\n";
         return -3;
     }
-    cbuf->depth = buf->type.bytes();
+    cbuf->depth = (buf->type.bits + 7) / 8;
     if (nDims > 2) {
-        for (size_t i = 0; i < nDims - 2; i++)
+        for (size_t i = 0; i < nDims - 2; i++) {
             cbuf->depth *= buf->dim[i].extent;
+        }
     }
     cbuf->width = buf->dim[nDims-2].extent;
     cbuf->height = buf->dim[nDims-1].extent;
     // TODO check stride of dimension are the same as width
     cbuf->stride = cbuf->width;
-
     int status = cma_get_buffer(cbuf);
     if (status != 0) {
         free(cbuf);
-        error(NULL) << "cma_get_buffer() returned" << status << " (failed).\n";
+        error(NULL) << "cma_get_buffer() returned " << status << "(failed).\n";
         return -2;
     }
-
+    uint32_t cma_buf_id = cbuf->id << 12;
     buf->device = (uint64_t) cbuf;
     buf->host = (uint8_t*) mmap(NULL, cbuf->stride * cbuf->height * cbuf->depth,
-                                PROT_WRITE, MAP_SHARED, fd_cma, cbuf->mmap_offset);
+                                PROT_WRITE, MAP_SHARED, fd_cma, cma_buf_id);
 
     if ((void *) buf->host == (void *) -1) {
         free(cbuf);
@@ -137,13 +183,11 @@ WEAK int halide_zynq_cma_alloc(struct halide_buffer_t *buf) {
 }
 
 WEAK int halide_zynq_cma_free(struct halide_buffer_t *buf) {
-    debug(0) << "halide_zynq_cma_free\n";
     if (fd_cma == 0) {
         error(NULL) << "Zynq runtime is uninitialized.\n";
         return -1;
     }
-
-    cma_buffer_t *cbuf = (cma_buffer_t *)buf->device;
+	UBuffer *cbuf = (UBuffer *)buf->device;
     munmap((void*)buf->host, cbuf->stride * cbuf->height * cbuf->depth);
     cma_free_buffer(cbuf);
     free(cbuf);
@@ -151,19 +195,26 @@ WEAK int halide_zynq_cma_free(struct halide_buffer_t *buf) {
     return 0;
 }
 
-WEAK int halide_zynq_subimage(const struct halide_buffer_t* image, struct cma_buffer_t* subimage, void *address_of_subimage_origin, int width, int height) {
+WEAK int halide_zynq_subimage(const struct halide_buffer_t* image, struct UBuffer* subimage, void *address_of_subimage_origin, int width, int height) {
     debug(0) << "halide_zynq_subimage\n";
-    *subimage = *((cma_buffer_t *)image->device); // copy depth, stride, data, etc.
+    *subimage = *((UBuffer *)image->device); // copy depth, stride, data, etc.
     subimage->width = width;
     subimage->height = height;
     size_t offset = (uint8_t *)address_of_subimage_origin - image->host;
-    subimage->phys_addr += offset;
-    subimage->mmap_offset += offset;
+
+    //subimage->phys_addr += offset;
+    //subimage->mmap_offset += offset;
+
+    /* the current implementation doesn't support offset any more */
+    if (offset != 0) {
+        error(NULL) << "subimage offset not 0\n";
+        return -1;
+    }
+
     return 0;
 }
 
-WEAK int halide_zynq_hwacc_launch(struct cma_buffer_t bufs[]) {
-    debug(0) << "halide_zynq_hwacc_launch\n";
+WEAK int halide_zynq_hwacc_launch(struct UBuffer bufs[]) {
     if (fd_hwacc == 0) {
         error(NULL) << "Zynq runtime is uninitialized.\n";
         return -1;
@@ -173,7 +224,6 @@ WEAK int halide_zynq_hwacc_launch(struct cma_buffer_t bufs[]) {
 }
 
 WEAK int halide_zynq_hwacc_sync(int task_id){
-    debug(0) << "halide_zynq_hwacc_sync\n";
     if (fd_hwacc == 0) {
         error(NULL) << "Zynq runtime is uninitialized.\n";
         return -1;


### PR DESCRIPTION
This PR works with the recent changes in `ultrazynqbuilder` drivers. Here is a list of detailed changes:
1. Proper `ioctl` commands. Instead of using hard-coded values, it now uses system-defined macros.
2. Switch from `cma_buffer_t` to `UBuffer`, which removes `phys_addr` and `kern_addr`