### PR TITLE
Working Zynq applications and travis test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -700,9 +700,10 @@ endif
 zynq_runtime: $(ROOT_DIR)/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp $(INCLUDE_DIR)/HalideRuntime.h
 	$(CXX) -c -Wall $(ROOT_DIR)/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp -o $(BUILD_DIR)/HalideRuntimeZynq.o -I$(INCLUDE_DIR)
 	ar rvs $(LIB_DIR)/libZynqRuntime.a $(BUILD_DIR)/HalideRuntimeZynq.o
-	# test zynq codegen
-	make -C apps/hls_examples/unsharp_hls/ run_zynq	
-	make -C apps/hls_examples/stereo_hls/ pipeline_zynq.o
+	# this tests zynq_llvm code gen
+	make -C apps/hls_examples/unsharp_hls/ run_zynq
+	# this tests zynq_c code gen
+	make -C apps/hls_examples/stereo_hls/ run_zynq
 
 $(INCLUDE_DIR)/Halide.h: $(HEADERS) $(SRC_DIR)/HalideFooter.h $(BIN_DIR)/build_halide_h
 	mkdir -p $(INCLUDE_DIR)

--- a/Makefile
+++ b/Makefile
@@ -700,6 +700,9 @@ endif
 zynq_runtime: $(ROOT_DIR)/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp $(INCLUDE_DIR)/HalideRuntime.h
 	$(CXX) -c -Wall $(ROOT_DIR)/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp -o $(BUILD_DIR)/HalideRuntimeZynq.o -I$(INCLUDE_DIR)
 	ar rvs $(LIB_DIR)/libZynqRuntime.a $(BUILD_DIR)/HalideRuntimeZynq.o
+	# test zynq codegen
+	make -C apps/hls_examples/unsharp_hls/ run_zynq	
+	make -C apps/hls_examples/stereo_hls/ pipeline_zynq.o
 
 $(INCLUDE_DIR)/Halide.h: $(HEADERS) $(SRC_DIR)/HalideFooter.h $(BIN_DIR)/build_halide_h
 	mkdir -p $(INCLUDE_DIR)

--- a/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp
+++ b/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp
@@ -182,6 +182,9 @@ int halide_zynq_cma_alloc(struct halide_buffer_t *buf) {
         printf("cma_get_buffer() returned %d (failed).\n", status);
         return -2;
     }
+    // use mem offset filed as cambuffer ID
+    // notice that since page size is 4K, the kernel will automatically
+    // shift the mem offset >> by 12. Hence we need to shift left 12 bits
     uint32_t cma_buf_id = cbuf->id << 12;
     buf->device = (uint64_t) cbuf;
     buf->host = (uint8_t*) mmap(NULL, cbuf->stride * cbuf->height * cbuf->depth,

--- a/apps/hls_examples/stereo_hls/Makefile
+++ b/apps/hls_examples/stereo_hls/Makefile
@@ -33,7 +33,7 @@ $(HLS_LOG): ../hls_support/run_hls.tcl pipeline_hls.cpp run.cpp
 #	$(CXX) -c -O2 $(CXXFLAGS) -g -Wall -Werror $^ -o $@  $(PNGFLAGS)
 
 run_zynq: pipeline_zynq.o pipeline_native.o run_zynq.cpp
-	$(CXX) -O3 $(CXXFLAGS) -Wall -Werror $^ -lpthread -ldl -o $@  $(PNGFLAGS)
+	$(CXX) -O3 $(CXXFLAGS) $(HLS_IFLAG) -Wall -Werror $^ -lpthread -ldl -o $@  $(PNGFLAGS)
 
 run_cuda: pipeline_native.o pipeline_cuda.o run_cuda.cpp
 	$(CXX) -O3 $(CXXFLAGS) -Wall -Werror $^ -lpthread -ldl -o $@  $(PNGFLAGS) `pkg-config --libs opencv`

--- a/apps/hls_examples/stereo_hls/Makefile
+++ b/apps/hls_examples/stereo_hls/Makefile
@@ -33,7 +33,7 @@ $(HLS_LOG): ../hls_support/run_hls.tcl pipeline_hls.cpp run.cpp
 #	$(CXX) -c -O2 $(CXXFLAGS) -g -Wall -Werror $^ -o $@  $(PNGFLAGS)
 
 run_zynq: pipeline_zynq.o pipeline_native.o run_zynq.cpp
-	$(CXX) -O3 $(CXXFLAGS) $(HLS_IFLAG) -Wall -Werror $^ -lpthread -ldl -o $@  $(IMAGE_IO_FLAGS)
+	$(CXX) -O3 $(CXXFLAGS) -Wall -Werror $^ -lpthread -ldl -o $@  $(IMAGE_IO_FLAGS)
 
 run_cuda: pipeline_native.o pipeline_cuda.o run_cuda.cpp
 	$(CXX) -O3 $(CXXFLAGS) -Wall -Werror $^ -lpthread -ldl -o $@  $(PNGFLAGS) `pkg-config --libs opencv`

--- a/apps/hls_examples/stereo_hls/Makefile
+++ b/apps/hls_examples/stereo_hls/Makefile
@@ -33,7 +33,7 @@ $(HLS_LOG): ../hls_support/run_hls.tcl pipeline_hls.cpp run.cpp
 #	$(CXX) -c -O2 $(CXXFLAGS) -g -Wall -Werror $^ -o $@  $(PNGFLAGS)
 
 run_zynq: pipeline_zynq.o pipeline_native.o run_zynq.cpp
-	$(CXX) -O3 $(CXXFLAGS) $(HLS_IFLAG) -Wall -Werror $^ -lpthread -ldl -o $@  $(PNGFLAGS)
+	$(CXX) -O3 $(CXXFLAGS) $(HLS_IFLAG) -Wall -Werror $^ -lpthread -ldl -o $@  $(IMAGE_IO_FLAGS)
 
 run_cuda: pipeline_native.o pipeline_cuda.o run_cuda.cpp
 	$(CXX) -O3 $(CXXFLAGS) -Wall -Werror $^ -lpthread -ldl -o $@  $(PNGFLAGS) `pkg-config --libs opencv`

--- a/apps/hls_examples/stereo_hls/pipeline.cpp
+++ b/apps/hls_examples/stereo_hls/pipeline.cpp
@@ -305,9 +305,8 @@ void compile_hls() {
     output.compile_to_header("pipeline_hls.h", args, "pipeline_hls", hls_target);
 
     // Create the Zynq platform target
-    std::vector<Target::Feature> features({Target::Zynq});
-    // use 64 bit since Zynq-ultrascale is 64bit
-    Target target(Target::Linux, Target::ARM, 64, features);
+    Target target = get_target_from_environment();
+    target.set_feature(Target::Zynq, true);
     output.compile_to_zynq_c("pipeline_zynq.c", args, "pipeline_zynq", target);
     output.compile_to_header("pipeline_zynq.h", args, "pipeline_zynq", target);
 

--- a/apps/hls_examples/stereo_hls/pipeline.cpp
+++ b/apps/hls_examples/stereo_hls/pipeline.cpp
@@ -306,7 +306,8 @@ void compile_hls() {
 
     // Create the Zynq platform target
     std::vector<Target::Feature> features({Target::Zynq});
-    Target target(Target::Linux, Target::ARM, 32, features);
+    // use 64 bit since Zynq-ultrascale is 64bit
+    Target target(Target::Linux, Target::ARM, 64, features);
     output.compile_to_zynq_c("pipeline_zynq.c", args, "pipeline_zynq", target);
     output.compile_to_header("pipeline_zynq.h", args, "pipeline_zynq", target);
 

--- a/apps/hls_examples/stereo_hls/run_zynq.cpp
+++ b/apps/hls_examples/stereo_hls/run_zynq.cpp
@@ -8,11 +8,11 @@
 #include "pipeline_zynq.h"
 #include "pipeline_native.h"
 
-#include "BufferMinimal.h"
+#include "HalideBuffer.h"
 #include "halide_image_io.h"
 
 using namespace Halide::Tools;
-using namespace Halide::Runtime::HLS;
+using namespace Halide::Runtime;
 
 extern "C" {
 extern int halide_zynq_init();
@@ -28,13 +28,13 @@ int main(int argc, char **argv) {
 
     // Halide::Buffer<T> cannot be automatically converted to halide_buffer_t*
     // use BufferMinimal<T> instead
-    BufferMinimal<uint8_t> left = load_image(argv[1]);
-    BufferMinimal<uint8_t> left_remap = load_image(argv[2]);
-    BufferMinimal<uint8_t> right = load_image(argv[3]);
-    BufferMinimal<uint8_t> right_remap = load_image(argv[4]);
+    Buffer<uint8_t> left = load_image(argv[1]);
+    Buffer<uint8_t> left_remap = load_image(argv[2]);
+    Buffer<uint8_t> right = load_image(argv[3]);
+    Buffer<uint8_t> right_remap = load_image(argv[4]);
 
-    BufferMinimal<uint8_t> out_native(left.width(), left.height());
-    BufferMinimal<uint8_t> out_zynq(600*4, 400*8);
+    Buffer<uint8_t> out_native(left.width(), left.height());
+    Buffer<uint8_t> out_zynq(600*4, 400*8);
 
     printf("start.\n");
 

--- a/apps/hls_examples/stereo_hls/run_zynq.cpp
+++ b/apps/hls_examples/stereo_hls/run_zynq.cpp
@@ -8,11 +8,13 @@
 #include "pipeline_zynq.h"
 #include "pipeline_native.h"
 
-#include "benchmark.h"
-#include "halide_image.h"
+#include "BufferMinimal.h"
 #include "halide_image_io.h"
 
 using namespace Halide::Tools;
+using namespace Halide::Runtime::HLS;
+
+extern int halide_zynq_init();
 
 int main(int argc, char **argv) {
     if (argc < 5) {
@@ -20,26 +22,17 @@ int main(int argc, char **argv) {
         return 0;
     }
     // Open the buffer allocation device
-    int cma = open("/dev/cmabuffer0", O_RDWR);
-    if(cma == -1){
-        printf("Failed to open cma provider!\n");
-        return(0);
-    }
+    halide_zynq_init();
 
-    // open the hardware
-    int hwacc = open("/dev/hwacc0", O_RDWR);
-    if(hwacc == -1) {
-        printf("Failed to open hardware device!\n");
-        return(0);
-    }
+    // Halide::Buffer<T> cannot be automatically converted to halide_buffer_t*
+    // use BufferMinimal<T> instead
+    BufferMinimal<uint8_t> left = load_image(argv[1]);
+    BufferMinimal<uint8_t> left_remap = load_image(argv[2]);
+    BufferMinimal<uint8_t> right = load_image(argv[3]);
+    BufferMinimal<uint8_t> right_remap = load_image(argv[4]);
 
-    Image<uint8_t> left = load_image(argv[1]);
-    Image<uint8_t> left_remap = load_image(argv[2]);
-    Image<uint8_t> right = load_image(argv[3]);
-    Image<uint8_t> right_remap = load_image(argv[4]);
-
-    Image<uint8_t> out_native(left.width(), left.height());
-    Image<uint8_t> out_zynq(600*4, 400*8);
+    BufferMinimal<uint8_t> out_native(left.width(), left.height());
+    BufferMinimal<uint8_t> out_zynq(600*4, 400*8);
 
     printf("start.\n");
 
@@ -49,7 +42,7 @@ int main(int argc, char **argv) {
     //out_native = load_image("out_native.png");
     //printf("cpu program results loaded.\n");
 
-    pipeline_zynq(right, left, right_remap, left_remap, out_zynq, hwacc, cma);
+    pipeline_zynq(right, left, right_remap, left_remap, out_zynq);
     save_image(out_zynq, "out_zynq.png");
     printf("accelerator program results saved.\n");
 
@@ -68,23 +61,6 @@ int main(int argc, char **argv) {
     } else {
       printf("passed.\n");
     }
-    printf("\nstart timing code...\n");
 
-    // Timing code. Timing doesn't include copying the input data to
-    // the gpu or copying the output back.
-    double min_t = benchmark(1, 1, [&]() {
-            pipeline_native(right, left, right_remap, left_remap, out_native);
-      });
-    printf("CPU program runtime: %g\n", min_t * 1e3);
-
-    // Timing code. Timing doesn't include copying the input data to
-    // the gpu or copying the output back.
-    double min_t2 = benchmark(5, 10, [&]() {
-       pipeline_zynq(right, left, right_remap, left_remap, out_zynq, hwacc, cma);
-      });
-    printf("accelerator program runtime: %g\n", min_t2 * 1e3);
-
-    close(hwacc);
-    close(cma);
     return 0;
 }

--- a/apps/hls_examples/stereo_hls/run_zynq.cpp
+++ b/apps/hls_examples/stereo_hls/run_zynq.cpp
@@ -26,8 +26,6 @@ int main(int argc, char **argv) {
     // Initialize zynq runtime
     halide_zynq_init();
 
-    // Halide::Buffer<T> cannot be automatically converted to halide_buffer_t*
-    // use BufferMinimal<T> instead
     Buffer<uint8_t> left = load_image(argv[1]);
     Buffer<uint8_t> left_remap = load_image(argv[2]);
     Buffer<uint8_t> right = load_image(argv[3]);

--- a/apps/hls_examples/stereo_hls/run_zynq.cpp
+++ b/apps/hls_examples/stereo_hls/run_zynq.cpp
@@ -14,14 +14,16 @@
 using namespace Halide::Tools;
 using namespace Halide::Runtime::HLS;
 
+extern "C" {
 extern int halide_zynq_init();
+}
 
 int main(int argc, char **argv) {
     if (argc < 5) {
         printf("Usage: ./run left.png left-remap.png right0224.png right-remap.png\n");
         return 0;
     }
-    // Open the buffer allocation device
+    // Initialize zynq runtime
     halide_zynq_init();
 
     // Halide::Buffer<T> cannot be automatically converted to halide_buffer_t*

--- a/apps/hls_examples/unsharp_hls/Makefile
+++ b/apps/hls_examples/unsharp_hls/Makefile
@@ -38,7 +38,7 @@ pipeline_zynq.o: pipeline_zynq.c
 	$(CXX) -c -O2 $(CXXFLAGS) -g -Wall -Werror $^ -o $@
 
 run_zynq.o: run_zynq.cpp
-	$(CXX) -c $(CXXFLAGS) $(HLS_IFLAG) -g -Wall -Werror $^ -o $@  $(PNGFLAGS)
+	$(CXX) -c $(CXXFLAGS) -g -Wall -Werror $^ -o $@  $(PNGFLAGS)
 
 HalideRuntimeZynq.o: ../hls_support/HalideRuntimeZynq.cpp
 	$(CXX) -Wall -Werror -I ../../../src/runtime $^ -c -o $@

--- a/apps/hls_examples/unsharp_hls/Makefile
+++ b/apps/hls_examples/unsharp_hls/Makefile
@@ -14,7 +14,7 @@ run_hls: $(HLS_LOG)
 pipeline: pipeline.cpp
 	$(CXX) $(CXXFLAGS) -Wall -g $^ $(LIB_HALIDE) -o $@ $(LDFLAGS) -ltinfo
 
-pipeline_hls.cpp pipeline_native.o pipeline_cuda.o pipeline_zynq.o: pipeline
+pipeline_hls.cpp pipeline_native.o pipeline_cuda.o pipeline_zynq.c: pipeline
 	HL_DEBUG_CODEGEN=0 ./pipeline
 
 run: run.cpp pipeline_hls.cpp hls_target.cpp pipeline_native.o
@@ -34,14 +34,17 @@ $(HLS_LOG): ../hls_support/run_hls.tcl pipeline_hls.cpp run.cpp
 	RUN_ARGS=$(realpath ./../../images/benchmark_8mp_rgb.png) \
 	vivado_hls -f $< -l $(HLS_LOG)
 
-#pipeline_zynq.o: pipeline_zynq.c
-#	$(CXX) -c -O2 $(CXXFLAGS) -g -Wall -Werror $^ -o $@
+pipeline_zynq.o: pipeline_zynq.c
+	$(CXX) -c -O2 $(CXXFLAGS) -g -Wall -Werror $^ -o $@
 
 run_zynq.o: run_zynq.cpp
-	$(CXX) -c $(CXXFLAGS) -g -Wall -Werror $^ -o $@  $(PNGFLAGS)
+	$(CXX) -c $(CXXFLAGS) $(HLS_IFLAG) -g -Wall -Werror $^ -o $@  $(PNGFLAGS)
 
-run_zynq: pipeline_zynq.o pipeline_native.o run_zynq.o
-	$(CXX) -Wall -Werror $^ -lpthread -ldl -o $@  $(PNGFLAGS)
+HalideRuntimeZynq.o: ../hls_support/HalideRuntimeZynq.cpp
+	$(CXX) -Wall -Werror -I ../../../src/runtime $^ -c -o $@
+
+run_zynq: pipeline_zynq.o pipeline_native.o run_zynq.o HalideRuntimeZynq.o
+	$(CXX) -Wall -Werror $^ -lpthread -ldl -o $@  $(IMAGE_IO_FLAGS)
 
 out_zynq.png: run_zynq
 	HL_NUM_THREADS=3 ./run_zynq  ../../images/benchmark_8mp_rgb.png

--- a/apps/hls_examples/unsharp_hls/pipeline.cpp
+++ b/apps/hls_examples/unsharp_hls/pipeline.cpp
@@ -148,7 +148,6 @@ public:
         //in.set_stride(0, 3).set_stride(2, 1).set_bounds(2, 0, 3);
         output.output_buffer().set_stride(0, 3).set_stride(2, 1);
 
-        output.compile_to_object("pipeline_zynq.o", args, "pipeline_zynq", target);
         output.compile_to_lowered_stmt("pipeline_zynq.ir.html", args, HTML, target);
         output.compile_to_assembly("pipeline_zynq.s", args, "pipeline_zynq", target);
     }

--- a/apps/hls_examples/unsharp_hls/run_zynq.cpp
+++ b/apps/hls_examples/unsharp_hls/run_zynq.cpp
@@ -8,31 +8,25 @@
 #include "pipeline_zynq.h"
 #include "pipeline_native.h"
 
-#include "benchmark.h"
-#include "halide_image.h"
+#include "BufferMinimal.h"
 #include "halide_image_io.h"
+
+using namespace Halide::Tools;
+using namespace Halide::Runtime::HLS;
+
+extern "C" {
+extern int halide_zynq_init();
+}
 
 using namespace Halide::Tools;
 
 int main(int argc, char **argv) {
     // Open the buffer allocation device
-    int cma = open("/dev/cmabuffer0", O_RDWR);
-    if(cma == -1){
-        printf("Failed to open cma provider!\n");
-        return(0);
-    }
+    halide_zynq_init();
 
-    // open the hardware
-    int hwacc = open("/dev/hwacc0", O_RDWR);
-    if(hwacc == -1) {
-        printf("Failed to open hardware device!\n");
-        return(0);
-    }
-
-
-    Image<uint8_t> input = load_image(argv[1]);
-    Image<uint8_t> out_native(2400, 3200, 3);
-    Image<uint8_t> out_zynq(480*5, 640*5, 3, 0, true);
+    BufferMinimal<uint8_t> input = load_image(argv[1]);
+    BufferMinimal<uint8_t> out_native(2400, 3200, 3);
+    BufferMinimal<uint8_t> out_zynq(480*5, 640*5, 3);
 
     printf("start.\n");
 
@@ -42,7 +36,7 @@ int main(int argc, char **argv) {
     //out_native = load_image("out_native.png");
     //printf("cpu program results loaded.\n");
 
-    pipeline_zynq(input, out_zynq, hwacc, cma);
+    pipeline_zynq(input, out_zynq);
     save_image(out_zynq, "out_zynq.png");
     printf("accelerator program results saved.\n");
 
@@ -66,23 +60,5 @@ int main(int argc, char **argv) {
         printf("%u fails.\n", fails);
     }
 
-    printf("\nstart timing code...\n");
-
-    // Timing code. Timing doesn't include copying the input data to
-    // the gpu or copying the output back.
-    double min_t = benchmark(1, 10, [&]() {
-            pipeline_native(input, out_native);
-        });
-    printf("CPU program runtime: %g\n", min_t * 1e3);
-
-    // Timing code. Timing doesn't include copying the input data to
-    // the gpu or copying the output back.
-    double min_t2 = benchmark(5, 20, [&]() {
-            pipeline_zynq(input, out_zynq, hwacc, cma);
-        });
-    printf("accelerator program runtime: %g\n", min_t2 * 1e3);
-
-    close(hwacc);
-    close(cma);
     return 0;
 }

--- a/apps/hls_examples/unsharp_hls/run_zynq.cpp
+++ b/apps/hls_examples/unsharp_hls/run_zynq.cpp
@@ -8,11 +8,11 @@
 #include "pipeline_zynq.h"
 #include "pipeline_native.h"
 
-#include "BufferMinimal.h"
+#include "HalideBuffer.h"
 #include "halide_image_io.h"
 
 using namespace Halide::Tools;
-using namespace Halide::Runtime::HLS;
+using namespace Halide::Runtime;
 
 extern "C" {
 extern int halide_zynq_init();
@@ -24,9 +24,9 @@ int main(int argc, char **argv) {
     // Open the buffer allocation device
     halide_zynq_init();
 
-    BufferMinimal<uint8_t> input = load_image(argv[1]);
-    BufferMinimal<uint8_t> out_native(2400, 3200, 3);
-    BufferMinimal<uint8_t> out_zynq(480*5, 640*5, 3);
+    Buffer<uint8_t> input = load_image(argv[1]);
+    Buffer<uint8_t> out_native(2400, 3200, 3);
+    Buffer<uint8_t> out_zynq(480*5, 640*5, 3);
 
     printf("start.\n");
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -279,11 +279,6 @@ CodeGen_LLVM *CodeGen_LLVM::new_for_target(const Target &target,
                         Target::OpenGL,
                         Target::OpenGLCompute,
                         Target::Metal})) << "Zynq feature cannot be enabled with GPU features.\n";
-        user_assert(target.arch == Target::ARM &&
-                    target.os == Target::Linux &&
-                    (target.bits == 32
-                     || target.bits == 64))
-            << "Zynq runtime only suport ARM Linux.\n";
         return make_codegen<CodeGen_Zynq_LLVM>(target, context);
     }
 

--- a/src/CodeGen_LLVM.cpp
+++ b/src/CodeGen_LLVM.cpp
@@ -281,8 +281,9 @@ CodeGen_LLVM *CodeGen_LLVM::new_for_target(const Target &target,
                         Target::Metal})) << "Zynq feature cannot be enabled with GPU features.\n";
         user_assert(target.arch == Target::ARM &&
                     target.os == Target::Linux &&
-                    target.bits == 32)
-            << "Zynq runtime only suport 32bit ARM Linux.\n";
+                    (target.bits == 32
+                     || target.bits == 64))
+            << "Zynq runtime only suport ARM Linux.\n";
         return make_codegen<CodeGen_Zynq_LLVM>(target, context);
     }
 

--- a/src/runtime/zynq.cpp
+++ b/src/runtime/zynq.cpp
@@ -169,6 +169,9 @@ WEAK int halide_zynq_cma_alloc(struct halide_buffer_t *buf) {
         error(NULL) << "cma_get_buffer() returned " << status << " (failed).\n";
         return -2;
     }
+    // use mem offset filed as cambuffer ID
+    // notice that since page size is 4K, the kernel will automatically
+    // shift the mem offset >> by 12. Hence we need to shift left 12 bits
     uint32_t cma_buf_id = cbuf->id << 12;
     buf->device = (uint64_t) cbuf;
     buf->host = (uint8_t*) mmap(NULL, cbuf->stride * cbuf->height * cbuf->depth,


### PR DESCRIPTION
This PR mainly deals with Zynq application compilation and tests. Here is a list of detailed changes:
1. Allow 64-bit ARM Zynq LLVM code generation. We're using Zynq Ultrascale+, which uses a 64-bit linux.
2. Working Zynq apps: `stereo_hls` and `unsharp_hls`. `stereo_hls` tests LLVM CodeGen whereas `unsharp_hls` tests Zynq_C CodeGen.
3. `stereo_hls` relies on `pipeline_zynq.o` generated directly from LLVM. Because the test environment uses x86/64, we might need to use a cross compiler. However, this will complicates things up a lot as it requires `libHalide.a` to be cross-compiled as well. As a result, the test stops at `pipeline_zynq.o` generation.
4. `unsharp_hls` relies on `pipeline_zynq.c` and can be fully compiled and linked. The travis test will check this.

+ add comments on why shifting 12 bits, which is due to page size.