### PR TITLE
Add tap support to Zynq

### DIFF
--- a/apps/hls_examples/blend_hls/Makefile
+++ b/apps/hls_examples/blend_hls/Makefile
@@ -1,0 +1,53 @@
+#### Halide flags
+HALIDE_BIN_PATH := ../../..
+HALIDE_SRC_PATH := ../../..
+include ../../support/Makefile.inc
+
+#### HLS flags
+include ../hls_support/Makefile.inc
+HLS_LOG = vivado_hls.log
+
+.PHONY: all run_hls
+all: out.png
+run_hls: $(HLS_LOG)
+
+pipeline: pipeline.cpp
+	$(CXX) $(CXXFLAGS) -Wall -g $^ $(LIB_HALIDE) -o $@ $(LDFLAGS) -ltinfo
+
+pipeline_hls_seedark.cpp seedark_pipeline.o pipeline_zynq_seedark.c: pipeline
+	HL_DEBUG_CODEGEN=0 ./pipeline
+
+run: run.cpp pipeline_hls_seedark.cpp hls_target.cpp seedark_pipeline.o
+	$(CXX) $(CXXFLAGS) -O1 -DNDEBUG $(HLS_CXXFLAGS) -g -Wall -Werror $^ -o $@ $(IMAGE_IO_FLAGS) $(LDFLAGS)
+
+out.png: run
+	./run ../../images/left0224.png ../../images/right0224.png
+
+$(HLS_LOG): ../hls_support/run_hls.tcl pipeline_hls_seedark.cpp run.cpp
+	RUN_PATH=$(realpath ./) \
+	RUN_ARGS=$(realpath ../../images/left0224.png) $(realpath ../../images/right0224.png) \
+	vivado_hls -f $< -l $(HLS_LOG)
+
+pipeline_zynq.o: pipeline_zynq_seedark.c
+	$(CXX) -c -O2 $(CXXFLAGS) -g -Wall -Werror $^ -o $@
+
+run_zynq.o: run_zynq.cpp
+	$(CXX) -c $(CXXFLAGS) -g -Wall -Werror $^ -o $@  $(PNGFLAGS)
+
+HalideRuntimeZynq.o: ../hls_support/HalideRuntimeZynq.cpp
+	$(CXX) -Wall -Werror -I ../../../src/runtime $^ -c -o $@
+
+run_zynq: pipeline_zynq.o seedark_pipeline.o run_zynq.o HalideRuntimeZynq.o
+	$(CXX) -Wall -Werror $^ -lpthread -ldl -o $@  $(IMAGE_IO_FLAGS)
+
+out_zynq.png: run_zynq
+	HL_NUM_THREADS=3 ./run_zynq  ../../images/left0224.png ../../images/right0224.png
+
+clean:
+	rm -f pipeline run run_zynq
+	rm -f out.png out_zynq.png
+	rm -f seedark_pipeline.h seedark_pipeline.o
+	rm -f pipeline_hls_seedark.cpp pipeline_hls_seedark.h
+	rm -f pipeline_zynq_seedark.c pipeline_zynq_seedark.h pipeline_zynq.o
+	rm -f run_zynq.o
+	rm -f hls_target.h hls_target.cpp

--- a/apps/hls_examples/blend_hls/pipeline.cpp
+++ b/apps/hls_examples/blend_hls/pipeline.cpp
@@ -1,0 +1,105 @@
+/* Blend two images with weighted addition
+ * Takes two 24-bit RGB images in, and returns a single 24-bit RGB of the same size.
+ * Steven Bell <sebell@stanford.edu>
+ * Keyi Zhang  <keyi@stanford.edu>
+ */
+
+#include "Halide.h"
+
+using namespace Halide;
+
+class BlendPipe
+{
+public:
+    ImageParam input1, input2;
+    ImageParam weight; // Two values, stored at 0(,0,0,0) and 1
+
+    Func padded1, padded2;
+    Func remap1, remap2;
+    Func sum, hw_sum;
+    Func blended;
+    Var x, y, c;
+    Var xo, yo, xi, yi;
+    std::vector<Argument> args;
+
+    Func blend_img(Func in1, Func in2, ImageParam &weight) {
+        /**
+         * Keyi: using weighted sum allows us to have more fine-grained control
+         * over weights given 0-255 range constraint
+         */
+        Func blend{"blend"};
+        blend(c, x, y) = cast<uint8_t>(clamp((cast<int16_t>(in1(c, x, y)) * weight(0) +
+                         cast<int16_t>(in2(c, x, y)) * weight(1)) / (weight(0) + weight(1)),
+                         0, 255));
+        return blend;
+    }
+
+    BlendPipe() : input1(UInt(8), 3), input2(UInt(8), 3), weight(UInt(8), 1)
+    {
+        padded1 = BoundaryConditions::constant_exterior(input1, 0);
+        padded2 = BoundaryConditions::constant_exterior(input2, 0);
+        
+        remap1(c, x, y) = padded1(x, y, c);
+        remap2(c, x, y) = padded2(x, y, c);
+
+        blended = blend_img(remap1, remap2, weight);
+
+        hw_sum(c, x, y) = blended(c, x, y);
+        sum(x, y, c) = hw_sum(c, x, y);
+
+        // Common schedule
+        sum.tile(x, y, xo, yo, xi, yi, 256, 256);
+        sum.reorder(c, xi, yi, xo, yo);
+
+        // Unroll across color; bound this to 3 channels
+        sum.bound(c, 0, 3);
+        hw_sum.bound(c, 0, 3);
+        // set bounds for weights
+        weight.dim(0).set_bounds(0, 2);
+
+        args = {input1, input2, weight};
+    }
+
+    void build_cpulib()
+    {
+        padded1.store_at(sum, xo).compute_at(sum, xi);
+        padded2.store_at(sum, xo).compute_at(sum, xi);
+        hw_sum.store_at(sum, xo).compute_at(sum, xi).unroll(c);
+
+        std::cout << "building pipeline for CPU as a static library..." << std::endl;
+        sum.compile_to_header("seedark_pipeline.h", args, "blend_cpu");
+        sum.compile_to_object("seedark_pipeline.o", args, "blend_cpu");
+    }
+
+    void generate_hls()
+    {
+        std::cout << "generating HLS code..." << std::endl;
+        hw_sum.tile(x, y, xo, yo, xi, yi, 256, 256).reorder(c, xi, yi, xo, yo);
+        hw_sum.compute_at(sum, xo);
+        remap1.compute_at(sum, xo);
+        remap2.compute_at(sum, xo);
+        blended.linebuffer();
+        // Accelerate the whole thing on the FPGA
+        hw_sum.accelerate({remap1, remap2}, xi, xo);
+
+        Target hls_target = get_target_from_environment();
+        hls_target.set_feature(Target::CPlusPlusMangling);
+        sum.compile_to_lowered_stmt("pipeline_hls.ir.html", args, HTML, hls_target);
+        sum.compile_to_hls("pipeline_hls_seedark.cpp", args, "pipeline_hls", hls_target);
+        sum.compile_to_header("pipeline_hls_seedark.h", args, "pipeline_hls", hls_target);
+
+        std::vector<Target::Feature> features({Target::Zynq});
+        Target target(Target::Linux, Target::ARM, 64, features);
+        sum.compile_to_zynq_c("pipeline_zynq_seedark.c", args, "pipeline_zynq", target);
+        sum.compile_to_header("pipeline_zynq_seedark.h", args, "pipeline_zynq", target);
+    }
+};
+
+int main(int argc, char* argv[])
+{
+    BlendPipe pipe_cpu, pipe_hls;
+    pipe_cpu.build_cpulib();
+    pipe_hls.generate_hls();
+    return 0;
+}
+

--- a/apps/hls_examples/blend_hls/run.cpp
+++ b/apps/hls_examples/blend_hls/run.cpp
@@ -1,0 +1,56 @@
+#include <cstdio>
+#include <cstdlib>
+#include <cassert>
+#include <math.h>
+
+#include "pipeline_hls_seedark.h"
+#include "seedark_pipeline.h"
+
+#include "HalideBuffer.h"
+#include "halide_image_io.h"
+
+using namespace Halide::Runtime;
+using namespace Halide::Tools;
+
+int main(int argc, char **argv) {
+    Buffer<uint8_t> input1 = load_image(argv[1]);
+    Buffer<uint8_t> input2 = load_image(argv[2]);
+    Buffer<uint8_t> weight(2, 1);
+    weight(0) = 5;
+    weight(1) = 95;
+    
+    Buffer<uint8_t> out_native(input1.width(), input1.height(), 3);
+    Buffer<uint8_t> out_hls(input1.width(), input1.height(), 3);
+
+    printf("start.\n");
+
+    blend_cpu(input1, input2, weight, out_native);
+    save_image(out_native, "out.png");
+
+    printf("finish running native code\n");
+    pipeline_hls(input1, input2, weight, out_hls);
+
+    printf("finish running HLS code\n");
+
+    bool pass = true;
+    for (int y = 0; y < out_hls.height(); y++) {
+        for (int x = 0; x < out_hls.width(); x++) {
+            for (int c = 0; c < out_hls.channels(); c++) {
+                if (out_native(x, y, c) != out_hls(x, y, c)) {
+                    printf("out_native(%d, %d, %d) = %d, but out_c(%d, %d, %d) = %d\n",
+                           x, y, c, out_native(x, y, c),
+                           x, y, c, out_hls(x, y, c));
+                    pass = false;
+                }
+          }
+	}
+    }
+    if (pass) {
+        printf("passed.\n");
+        return 0;
+    } else  {
+        printf("failed.\n");
+        return 1;
+    }
+    return 0;
+}

--- a/apps/hls_examples/blend_hls/run_zynq.cpp
+++ b/apps/hls_examples/blend_hls/run_zynq.cpp
@@ -1,0 +1,68 @@
+#include <cstdio>
+#include <cstdlib>
+#include <cassert>
+#include <math.h>
+
+#include <fcntl.h>
+#include <unistd.h>
+#include "pipeline_zynq_seedark.h"
+#include "seedark_pipeline.h"
+
+#include "HalideBuffer.h"
+#include "halide_image_io.h"
+
+using namespace Halide::Tools;
+using namespace Halide::Runtime;
+
+extern "C" {
+extern int halide_zynq_init();
+}
+
+using namespace Halide::Tools;
+
+int main(int argc, char **argv) {
+    // Open the buffer allocation device
+    halide_zynq_init();
+
+    Buffer<uint8_t> input1 = load_image(argv[1]);
+    Buffer<uint8_t> input2 = load_image(argv[2]);
+    Buffer<uint8_t> weight(2, 1);
+    weight(0) = 5;
+    weight(1) = 95;
+    
+    Buffer<uint8_t> out_native(input1.width(), input1.height(), 3);
+    Buffer<uint8_t> out_zynq(input1.width(), input1.height(), 3);
+    printf("start.\n");
+
+    blend_cpu(input1, input2, weight, out_native);
+    save_image(out_native, "out.png");
+    printf("cpu program results saved.\n");
+    //out_native = load_image("out_native.png");
+    //printf("cpu program results loaded.\n");
+
+    pipeline_zynq(input1, input2, weight, out_zynq);
+    save_image(out_zynq, "out_zynq.png");
+    printf("accelerator program results saved.\n");
+
+    printf("checking results...\n");
+    unsigned fails = 0;
+    for (int y = 0; y < out_zynq.height(); y++) {
+        for (int x = 0; x < out_zynq.width(); x++) {
+            for (int c = 0; c < out_zynq.channels(); c++) {
+                if (out_native(x, y, c) != out_zynq(x, y, c)) {
+                    printf("out_native(%d, %d, %d) = %d, but out_c(%d, %d, %d) = %d\n",
+                           x, y, c, out_native(x, y, c),
+                           x, y, c, out_zynq(x, y, c));
+                    fails++;
+                }
+            }
+        }
+    }
+    if (!fails) {
+        printf("passed.\n");
+    } else  {
+        printf("%u fails.\n", fails);
+    }
+
+    return 0;
+}

--- a/apps/hls_examples/blend_hls/run_zynq.cpp
+++ b/apps/hls_examples/blend_hls/run_zynq.cpp
@@ -37,8 +37,6 @@ int main(int argc, char **argv) {
     blend_cpu(input1, input2, weight, out_native);
     save_image(out_native, "out.png");
     printf("cpu program results saved.\n");
-    //out_native = load_image("out_native.png");
-    //printf("cpu program results loaded.\n");
 
     pipeline_zynq(input1, input2, weight, out_zynq);
     save_image(out_zynq, "out_zynq.png");

--- a/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp
+++ b/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp
@@ -249,7 +249,7 @@ void buffer_to_stencil(struct halide_buffer_t* image, struct UBuffer* stencil) {
     }
     stencil->width = image->dim[nDims - 2].extent; // length of the array
     stencil->height = image->dim[nDims - 1].extent;
-    stencil->depth = (image->type.bits + 7) / 8;
+    stencil->depth = image->type.bytes();
     if (stencil->height != 1)
         printf("stencil height is not 1\n");
     // we assume tap values are 1D array. hence its height = 1,

--- a/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp
+++ b/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp
@@ -242,6 +242,23 @@ int halide_zynq_hwacc_sync(int task_id){
     return res;
 }
 
+void buffer_to_stencil(struct halide_buffer_t* image, struct UBuffer* stencil) {
+    size_t nDims = image->dimensions;
+    if (nDims < 2) {
+        printf("buffer_t has less than 2 dimension, not supported in CMA driver.");
+    }
+    stencil->width = image->dim[nDims - 2].extent; // length of the array
+    stencil->height = image->dim[nDims - 1].extent;
+    stencil->depth = (image->type.bits + 7) / 8;
+    if (stencil->height != 1)
+        printf("stencil height is not 1\n");
+    // we assume tap values are 1D array. hence its height = 1,
+    // as a result, we can use this to tell tap/stream apart
+    // wrap user memory addr to the id(high) and stride(low) field
+    uint64_t addr = (uint64_t)image->host;
+    stencil->id = 0xFFFFFFFF & (addr >> 32);
+    stencil->stride = 0xFFFFFFFF & addr;
+}
 
 #ifdef __cplusplus
 } // End extern "C"

--- a/src/CodeGen_Zynq_LLVM.cpp
+++ b/src/CodeGen_Zynq_LLVM.cpp
@@ -16,7 +16,8 @@ CodeGen_Zynq_LLVM::CodeGen_Zynq_LLVM(Target t)
     : CodeGen_ARM(t) { }
 
 void CodeGen_Zynq_LLVM::visit(const Realize *op) {
-    internal_assert(ends_with(op->name, ".stream"));
+    internal_assert(ends_with(op->name, ".stream") ||
+                    ends_with(op->name, ".tap.stencil"));
     llvm::StructType *kbuf_type = module->getTypeByName("struct.UBuffer");
     internal_assert(kbuf_type);
     llvm::Constant *one = llvm::ConstantInt::get(i32_t, 1);
@@ -124,6 +125,18 @@ void CodeGen_Zynq_LLVM::visit(const Call *op) {
         internal_assert(load->index.type().is_scalar()) << "Can't take the address of a vector load\n";
 
         value = codegen_buffer_pointer(load->name, load->type, load->index);
+    } else if (op->name == "buffer_to_stencil") {
+        /**
+         * disguise tap value as buffer and handle that in the kernel driver,
+         * assuming tap values are one-dimensional array
+         * (at least for the current applications).
+         */
+        internal_assert(op->args.size() == 2);
+        Value *buffer = codegen(op->args[0]);
+        Value *stencil = codegen(op->args[1]);
+        llvm::Function *fn = module->getFunction("buffer_to_stencil");
+        internal_assert(fn);
+        value = builder->CreateCall(fn, {buffer, stencil});
     } else {
         CodeGen_ARM::visit(op);
     }


### PR DESCRIPTION
This PR handles tap values generated by HLS on Zynq platform. Detailed changes:
1. Introduce `buffer_to_stencil` in Zynq codegen, which wraps user data with a `UBuffer` and set `height = 1`. 
    + It is reasonable to assume that tap values are 1D data, otherwise one can easily made it into a `stream` instead of tap stencil.
    + The kernel driver, upon receiving `UBuffer`, will check the height. If the buffer height is 1, it will copy the values and write to register space, instead of sending data to DMA channel.
   + No cma buffer allocation needed.
2. Add an app called `blend_hls`, which blends two images given weight (tap values). This can be further implemented to `seedark` in camera apps.