### PR TITLE
Add input kernel checking to prevent segfault

### DIFF
--- a/src/StreamOpt.cpp
+++ b/src/StreamOpt.cpp
@@ -669,7 +669,7 @@ class StreamOpt : public IRMutator {
 
             // insert line buffers for input streams
             for (const string &kernel_name : dag.input_kernels) {
-                internal_assert(dag.kernels.count(kernel_name)) << kernel_name
+                user_assert(dag.kernels.count(kernel_name)) << kernel_name
                     << " not found in kernels. Did you forget to schedule for "
                     << kernel_name << "?";
                 const HWKernel &input_kernel = dag.kernels.find(kernel_name)->second;

--- a/src/StreamOpt.cpp
+++ b/src/StreamOpt.cpp
@@ -669,6 +669,9 @@ class StreamOpt : public IRMutator {
 
             // insert line buffers for input streams
             for (const string &kernel_name : dag.input_kernels) {
+                internal_assert(dag.kernels.count(kernel_name)) << kernel_name
+                    << " not found in kernels. Did you forget to schedule for "
+                    << kernel_name << "?";
                 const HWKernel &input_kernel = dag.kernels.find(kernel_name)->second;
                 new_body = add_linebuffer(new_body, input_kernel);
             }


### PR DESCRIPTION
This PR adds check to linebuffer generation. Currently if the user forget to schedule for the input functions (see below), the code will continue to execute since `::end()` returns a valid pointer so `->second` can still deference `::end()`.

```C++
// input1.compute_at(output, xo);
hw_output.accelerate({input1}, xi, xo);    // <- segfault
```