### PR TITLE
Fix cma free buffer ioctl call

### DIFF
--- a/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp
+++ b/apps/hls_examples/hls_support/HalideRuntimeZynq.cpp
@@ -141,7 +141,7 @@ static int cma_get_buffer(UBuffer* ptr) {
 }
 
 static int cma_free_buffer(UBuffer* ptr) {
-    return ioctl(fd_cma, FREE_IMAGE, (long unsigned int)ptr);
+    return ioctl(fd_cma, FREE_BUFFER, (long unsigned int)ptr);
 }
 
 int halide_zynq_cma_alloc(struct halide_buffer_t *buf) {

--- a/src/runtime/zynq.cpp
+++ b/src/runtime/zynq.cpp
@@ -127,7 +127,7 @@ static int cma_get_buffer(UBuffer* ptr) {
 }
 
 static int cma_free_buffer(UBuffer* ptr) {
-    return ioctl(fd_cma, FREE_IMAGE, (long unsigned int)ptr);
+    return ioctl(fd_cma, FREE_BUFFER, (long unsigned int)ptr);
 }
 
 WEAK int halide_zynq_cma_alloc(struct halide_buffer_t *buf) {


### PR DESCRIPTION
This PR fixes a bug due to ioctl command changes in Zynq kernel drivers.